### PR TITLE
Fix index out-of-bounds in 0x028 parsing

### DIFF
--- a/helpers/PacketParsers.cs
+++ b/helpers/PacketParsers.cs
@@ -1677,8 +1677,8 @@ namespace PacketViewerLogViewer
                 {
                     // This packet is too complex to do the normal way (for now)
                     var bytesfor0x028 = Parse_Packet_In_0x028(PD,ref DataFieldIndex);
-                    var maxIndex = Math.Min(bytesfor0x028, ParsedBytes.Count);
-                    // Mark any byts that didn't get marked as parsed, as parsed
+                    var maxIndex = Math.Min(bytesfor0x028, ParsedBytes.Count); // Fix for if parsing did something wrong, credits to InoUno
+                    // Mark any bytes that didn't get marked as parsed, as parsed
                     for (int i = 0; i < maxIndex; i++)
                     {
                         if (ParsedBytes[i] == 0)

--- a/helpers/PacketParsers.cs
+++ b/helpers/PacketParsers.cs
@@ -1677,8 +1677,9 @@ namespace PacketViewerLogViewer
                 {
                     // This packet is too complex to do the normal way (for now)
                     var bytesfor0x028 = Parse_Packet_In_0x028(PD,ref DataFieldIndex);
+                    var maxIndex = Math.Min(bytesfor0x028, ParsedBytes.Count);
                     // Mark any byts that didn't get marked as parsed, as parsed
-                    for (int i = 0; i < bytesfor0x028; i++)
+                    for (int i = 0; i < maxIndex; i++)
                     {
                         if (ParsedBytes[i] == 0)
                             ParsedBytes[i] = 0xFF;


### PR DESCRIPTION
Encountered an error while trying to view some of my recent packet logs, and traced it down to the an index out-of-bounds error for the `ParsedBytes` array here:
https://github.com/ZeromusXYZ/PacketViewerLogViewer/blob/e8343951faa4ec5e42bf87ea5d40e00cb53ac0f6/helpers/PacketParsers.cs#L1679-L1685

Example logs that cause it to error out:
[packets_6.11.2020-5_53_20.log](https://github.com/ZeromusXYZ/PacketViewerLogViewer/files/4765824/packets_6.11.2020-5_53_20.log)
[packets_6.11.2020-5_54_20.log](https://github.com/ZeromusXYZ/PacketViewerLogViewer/files/4765825/packets_6.11.2020-5_54_20.log)

I've added a workaround in this PR that at least makes it able to open the files, although I doubt it's the proper fix for the underlying problem.

I am not familiar with the packet structure or parsing of it in this piece of code, so I don't know what the right fix would be, without spending a lot of time digging into the code.
